### PR TITLE
unit test data update

### DIFF
--- a/cosmic/utils.py
+++ b/cosmic/utils.py
@@ -960,6 +960,13 @@ def error_check(BSEDict, filters=None, convergence=None, sampling=None):
 
     flag = "zsun"
     if flag in BSEDict.keys():
+        if BSEDict[flag] != 0.019:
+            warnings.warn(
+                "'{0:s}' is set to a different value than assumed in the mlwind "
+                "prescriptions (you set it to '{1:0.2f}' and in mlwind, zsun_wind=0.019)".format(
+                    flag, BSEDict[flag]
+                )
+            )
         if BSEDict[flag] <= 0:
             raise ValueError(
                 "'{0:s}' needs to be greater than 0 (you set it to '{1:0.2f}')".format(

--- a/docs/inifile/index.rst
+++ b/docs/inifile/index.rst
@@ -305,7 +305,10 @@ sampling
 
 =======================  =====================================================
 ``zsun``                 Sets the metallicity of the Sun which primarily affects
-                         stellar winds.
+                         stellar winds. Note that our wind prescriptions apply a 
+                         fixed zsun parameter: zsun_wind = 0.019 because the wind 
+                         prescriptions are calibrated to this value as described in
+                         `Vink+2001. <https://ui.adsabs.harvard.edu/abs/2001A%26A...369..574V/abstract>`_
 
                          **zsun = 0.014** following `Asplund 2009 <https://ui.adsabs.harvard.edu/abs/2009ARA%26A..47..481A/abstract>`_
 =======================  =====================================================

--- a/examples/Params.ini
+++ b/examples/Params.ini
@@ -145,7 +145,9 @@ pts3 = 0.02
 ;;; METALLICITY FLAGS ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ; specify the value for Solar metallicity, which primarily affects
-; winds in BSE
+; winds in BSE Note that our wind prescriptions apply a 
+; fixed zsun parameter: zsun_wind = 0.019 because the wind 
+; prescriptions are calibrated to this value as described in Vink+2001
 ; default = 0.014 (Asplund+2009)
 zsun = 0.014
 


### PR DESCRIPTION
The unit tests broke in a very predictable way, since fixing zsun_wind to a different value changes the wind mass loss by a small fraction. Since our evolve unit tests are bit by bit comparisons of dataframes, this small change breaks that comparison. As a quick fix, I've just updated the test data, though in the end, this is yet another reminder of how future tests which are physics motivated in the fortran (or maybe future cosmic language yet to be determined!) would be better!
